### PR TITLE
renamed make target to ci-test-including-end2end

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ elifePipeline {
             withDataPipelineGcpCredentials {
                 try {
                     sh "make build-dev"
-                    sh "make ci-end2end-test"
+                    sh "make ci-test-including-end2end"
                 } finally {
                     sh "make ci-clean"
                 }

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ build-dev:
 ci-test-exclude-e2e: build-dev
 	$(DOCKER_COMPOSE) run --rm peerscout-dags-dev ./run_test.sh
 
-ci-end2end-test: build-dev
+ci-test-including-end2end: build-dev
 	$(DOCKER_COMPOSE) run --rm  test-client
 	$(DOCKER_COMPOSE) down -v
 


### PR DESCRIPTION
I noticed that when looking at Jenkins test failure. I was confused by the previous `ci-end2end-test` as it suggested it would only cover end2end tests.