### PR TITLE
fixed division by zero

### DIFF
--- a/peerscout/keyword_extract/keyword_extract.py
+++ b/peerscout/keyword_extract/keyword_extract.py
@@ -8,7 +8,7 @@ import re
 import logging
 from tempfile import TemporaryDirectory
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Iterable, Iterator, List, Tuple, T
 import datetime
 from itertools import tee
 from datetime import timezone
@@ -313,12 +313,12 @@ def write_to_jsonl_file(
             write_file.write("\n")
 
 
-def iter_get_batches(iterable, size):
+def iter_get_batches(iterator: Iterator[T], size: int) -> Iterable[T]:
     while True:
         chunk = []
         for _ in range(size):
             try:
-                chunk.append(next(iterable))
+                chunk.append(next(iterator))
             except StopIteration:
                 if chunk:
                     yield chunk

--- a/peerscout/keyword_extract/keyword_extract.py
+++ b/peerscout/keyword_extract/keyword_extract.py
@@ -320,7 +320,8 @@ def iter_get_batches(iterable, size):
             try:
                 chunk.append(next(iterable))
             except StopIteration:
-                yield chunk
+                if chunk:
+                    yield chunk
                 return
         yield chunk
 

--- a/tests/unit_test/keyword_extract/keyword_extract_test.py
+++ b/tests/unit_test/keyword_extract/keyword_extract_test.py
@@ -7,6 +7,7 @@ from spacy.language import Language
 
 import peerscout.keyword_extract.keyword_extract as keyword_extract_module
 from peerscout.keyword_extract.keyword_extract import (
+    iter_get_batches,
     to_unique_keywords,
     SimpleKeywordExtractor,
     SpacyKeywordExtractor,
@@ -26,6 +27,26 @@ def _spacy_keyword_document_parser_class_mock():
 def _spacy_keyword_document_parser_mock(
         spacy_keyword_document_parser_class_mock: MagicMock):
     return spacy_keyword_document_parser_class_mock.return_value
+
+
+class TestIterGetBatches:
+    def test_should_not_return_any_batches_if_iterator_produces_no_items(self):
+        assert list(iter_get_batches(
+            iter([]),
+            2
+        )) == []
+
+    def test_should_return_full_batches(self):
+        assert list(iter_get_batches(
+            iter([1, 2, 3, 4]),
+            2
+        )) == [[1, 2], [3, 4]]
+
+    def test_should_return_last_partial_batch(self):
+        assert list(iter_get_batches(
+            iter([1, 2, 3, 4, 5]),
+            2
+        )) == [[1, 2], [3, 4], [5]]
 
 
 class TestToUniqueKeywords:


### PR DESCRIPTION

Got `ZeroDivisionError` after applying #91. I believe that is because `iter_get_batches` produced an empty batch even though the input was empty.

Log:

```text
[2020-06-24 08:53:38,769] {{logging_mixin.py:112}} INFO - [2020-06-24 08:53:38,769] {{keyword_extract.py:157}} INFO - total_rows: 0 (batch size: 2000, total batch count: 0)
[2020-06-24 08:53:38,939] {{taskinstance.py:1145}} ERROR - float division by zero
Traceback (most recent call last):
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 983, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/operators/python_operator.py", line 113, in execute
    return_value = self.execute_callable()
  File "/usr/local/airflow/.local/lib/python3.7/site-packages/airflow/operators/python_operator.py", line 118, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/usr/local/airflow/dags/dags/keyword_extraction_pipeline.py", line 128, in etl_extraction_keyword
    multi_keyword_extract_conf.state_file_object_name
  File "/usr/local/airflow/dags/dags/keyword_extraction_pipeline.py", line 159, in etl_and_update_state
    state_dict
  File "/usr/local/airflow/git_repos/peerscout_dag/peerscout/keyword_extract/keyword_extract.py", line 191, in etl_keywords
    (100.0 * progress_monitor / total_batch_count),
ZeroDivisionError: float division by zero
```