### PR TITLE
pinned cloudpickle to 1.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 apache-airflow[crypto,postgres,jdbc]==1.10.10
 boto3==1.14.12
 google-cloud-bigquery==1.25.0
+cloudpickle==1.4.1
 dateparser==0.7.6
 dask[complete]==2.19.0
 distributed==2.19.0


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5823

due to Airflow scheduler / end to end test issue