### PR TITLE
downgraded cattrs to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 apache-airflow[crypto,postgres,jdbc]==1.10.12
 boto3==1.16.7
 google-cloud-bigquery==2.2.0
+cattrs==1.0.0
 cloudpickle==1.4.1
 dateparser==0.7.6
 dask[complete]==2.30.0


### PR DESCRIPTION
see https://github.com/elifesciences/data-hub-core-airflow-dags/pull/238

this has now caused other PRs to fail