### PR TITLE
Revert "Bump google-cloud-bigquery from 2.3.1 to 2.4.0 (#235)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apache-airflow[crypto,postgres,jdbc]==1.10.12
 boto3==1.16.19
-google-cloud-bigquery==2.4.0
+google-cloud-bigquery==2.3.1
 cattrs==1.0.0
 cloudpickle==1.4.1
 dateparser==1.0.0


### PR DESCRIPTION
This reverts commit 31d9c71e97c8ef21eeace0bd9bc4191d54d33e8a.

This caused it to hang trying to read data from BigQuery via pandas-gbq.
(e.g. in the `peerscout-build-reviewing-editor-profiles` notebook)