### PR TITLE
added limits for dask version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ google-cloud-bigquery==2.32.0
 cattrs==1.10.0
 cloudpickle==1.4.1
 dateparser==1.1.0
-dask[complete]<2021.12.0
-distributed<=2021.2.0
+dask[complete]<2021.12.0, >=2.17.0
+distributed<=2021.2.0, >=2.17.0
 bigquery-schema-generator==1.5


### PR DESCRIPTION
creating image taking too long because of wide range of requirements version of dask.

https://github.com/elifesciences/data-hub-issues/issues/357